### PR TITLE
[feat] add base codes for deploying our codes as greengrass lambda

### DIFF
--- a/greengrass/binder/binder.py
+++ b/greengrass/binder/binder.py
@@ -1,0 +1,2 @@
+def handler(event, context):
+    pass

--- a/greengrass/binder/function.conf
+++ b/greengrass/binder/function.conf
@@ -1,0 +1,12 @@
+conf {
+  language = "PYTHON3_7"
+  functionName = "binder"
+  handlerName = "binder.handler"
+  memorySizeInKb = 131072
+  pinned = true
+  timeoutInSeconds = 3
+  fromCloudSubscriptions = []
+  toCloudSubscriptions = ["edge/"${AWS_GREENGRASS_GROUP_NAME}"/data/raw"]
+  outputTopics = []
+  inputTopics = []
+}

--- a/greengrass/canPlguin/can_plugin.py
+++ b/greengrass/canPlguin/can_plugin.py
@@ -1,0 +1,2 @@
+def handler(event, context):
+    pass

--- a/greengrass/canPlguin/function.conf
+++ b/greengrass/canPlguin/function.conf
@@ -1,0 +1,12 @@
+conf {
+  language = "PYTHON3_7"
+  functionName = "canPlugin"
+  handlerName = "can_plugin.handler"
+  memorySizeInKb = 131072
+  pinned = true
+  timeoutInSeconds = 3
+  fromCloudSubscriptions = []
+  toCloudSubscriptions = ["edge/"${AWS_GREENGRASS_GROUP_NAME}"/data/raw"]
+  outputTopics = []
+  inputTopics = []
+}

--- a/greengrass/testPlugin/function.conf
+++ b/greengrass/testPlugin/function.conf
@@ -1,0 +1,12 @@
+conf {
+  language = "PYTHON3_7"
+  functionName = "testPlugin"
+  handlerName = "test_plugin.handler"
+  memorySizeInKb = 131072
+  pinned = true
+  timeoutInSeconds = 3
+  fromCloudSubscriptions = []
+  toCloudSubscriptions = ["edge/"${AWS_GREENGRASS_GROUP_NAME}"/data/raw"]
+  outputTopics = []
+  inputTopics = []
+}

--- a/greengrass/testPlugin/test_plugin.py
+++ b/greengrass/testPlugin/test_plugin.py
@@ -1,0 +1,2 @@
+def handler(event, context):
+    pass

--- a/greengrass/webServerDaemon/function.conf
+++ b/greengrass/webServerDaemon/function.conf
@@ -1,0 +1,12 @@
+conf {
+  language = "PYTHON3_7"
+  functionName = "webServerDaemon"
+  handlerName = "web_server.handler"
+  memorySizeInKb = 131072
+  pinned = true
+  timeoutInSeconds = 3
+  fromCloudSubscriptions = []
+  toCloudSubscriptions = ["edge/"${AWS_GREENGRASS_GROUP_NAME}"/data/raw"]
+  outputTopics = []
+  inputTopics = []
+}

--- a/greengrass/webServerDaemon/web_server.py
+++ b/greengrass/webServerDaemon/web_server.py
@@ -1,0 +1,2 @@
+def handler(event, context):
+    pass

--- a/greengrass/webSocketServerDaemon/function.conf
+++ b/greengrass/webSocketServerDaemon/function.conf
@@ -1,0 +1,12 @@
+conf {
+  language = "PYTHON3_7"
+  functionName = "webSocketServer"
+  handlerName = "web_socket_server.handler"
+  memorySizeInKb = 131072
+  pinned = true
+  timeoutInSeconds = 3
+  fromCloudSubscriptions = []
+  toCloudSubscriptions = ["edge/"${AWS_GREENGRASS_GROUP_NAME}"/data/raw"]
+  outputTopics = []
+  inputTopics = []
+}

--- a/greengrass/webSocketServerDaemon/web_socket_server.py
+++ b/greengrass/webSocketServerDaemon/web_socket_server.py
@@ -1,0 +1,2 @@
+def handler(event, context):
+    pass


### PR DESCRIPTION
차량으로부터 라즈베리파이가 데이터를 수집하는 부분을 `greengrass` 람다를 활용해서 구현하기 위해 베이스 코드를 작성합니다.

구조는 `can` 플러그인이 실제 차량으로부터 데이터를 수집하고, `binder`라는 프로세스와 ipc를 통해 데이터를 전달,

`binder`는 각 dispatcher (CSV파일 생성, mqtt 전송, S3에 저장, influxdb에 데이터 저장 등)로 데이터를 `relay` 할 계획입니다.

즉 `binder`가 실제 데이터를 프로세싱하고, 어딘가로 전송하는 역할을 할 예정입니다. 

greengrass로 진행하는 이유는, 원격 업데이트 가능 및 강력한 로깅 기능이 있어서 사용합니다. 

